### PR TITLE
display projects and associated palettes

### DIFF
--- a/src/components/Project/Project.js
+++ b/src/components/Project/Project.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import { connect } from 'react-redux'
+
+export const Project = (props) => {
+    const { name, id } = props.project
+    const palettes = props.palettes.filter(palette => {
+      return palette.project_id === id
+    }).map(palette => {
+      return <div key={palette.id}>{palette.palette_name}</div>
+    })
+
+    return(
+      <div>
+        {name}
+        {palettes}
+      </div>
+    )
+}
+
+const mapStateToProps = (state) => ({
+  palettes: state.palettes
+})
+
+export default connect(mapStateToProps)(Project)

--- a/src/containers/Projects/Projects.js
+++ b/src/containers/Projects/Projects.js
@@ -1,11 +1,22 @@
 import React from 'react'
+import Project from '../../components/Project/Project'
+import { connect } from 'react-redux'
 
-export const Projects = () => {
+export const Projects = (props) => {
+    
+    const projects = props.projects.map(project => {
+      return <Project key={project.id} project={project}/>
+    })
+    
     return(
       <div>
-        Projects
+        {projects}
       </div>
     )
 }
 
-export default Projects
+const mapStateToProps = (state) => ({
+  projects: state.projects
+})
+
+export default connect(mapStateToProps)(Projects)


### PR DESCRIPTION
## Title: 
Display Projects/Palettes

#### Description of changes made: 
Map over Redux store to display projects and associated palettes at /my-projects

#### Link to issue this PR addresses: 
[Display projects on projects page](https://github.com/easbell/palette-picker-ui/issues/28)

#### Link to new issues that address next steps: 
[Handle displaying individual projects for edit/delete](https://github.com/easbell/palette-picker-ui/issues/30)