### PR TITLE
delete projects and linked palettes

### DIFF
--- a/src/containers/EditProject/EditProject.js
+++ b/src/containers/EditProject/EditProject.js
@@ -2,27 +2,59 @@ import React from 'react'
 import { connect } from 'react-redux'
 import '../../components/Project/Project.css'
 import EditPalette from '../EditPalette/EditPalette'
+import { setProjects, setPalettes } from '../../actions'
+import { deletePaletteBE, deleteProjectBE } from '../../helpers/apiCalls'
+import { withRouter } from 'react-router-dom'
 
 export const EditProject = (props) => {
   const { name, id } = props.foundProject
   const palettes = props.palettes.filter(palette => {
-    return palette.project_id === id}).map(palette => {
+    return palette.project_id === id
+  }).map(palette => {
       return <EditPalette key={palette.id} palette={palette}/>
     })
+
+  const deleteProject = (id) => {
+    const updatedProjects = props.projects.filter(project => {
+      return project.id !== id
+    })
+    props.setProjects(updatedProjects)
+    deleteProjectBE(id)
+    deleteLinkedPalettes(id)
+  }
+
+  const deleteLinkedPalettes = (id) => {
+    props.palettes.filter(palette => {
+      return palette.project_id === id
+    }).forEach(palette => {
+      deletePaletteBE(palette.id)
+    })
+    const unlinkedPalettes = props.palettes.filter(palette => {
+      return palette.project_id !== id
+    })
+    setPalettes(unlinkedPalettes)
+    props.history.push('/my-projects')
+  }
 
   return (
     <div className='project-card edit-project-card'>
       <h2 className='project-name'>{name}</h2>
       {palettes}
       <div className='delete-btn-container'>
-        <button className='delete-project'>Delete Project</button>
+        <button className='delete-project' onClick={() => deleteProject(id)}>Delete Project</button>
       </div>
     </div>
   )
 }
 
 const mapStateToProps = (state) => ({
-  palettes: state.palettes
+  palettes: state.palettes,
+  projects: state.projects
 })
 
-export default connect(mapStateToProps)(EditProject)
+const mapDispatchToProps = (dispatch) => ({
+  setProjects: (projects) => dispatch(setProjects(projects)),
+  setPalettes: (palettes) => dispatch(setPalettes(palettes))
+})
+
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(EditProject))

--- a/src/helpers/apiCalls.js
+++ b/src/helpers/apiCalls.js
@@ -14,3 +14,20 @@ export const deletePaletteBE = async (id) => {
     console.log(error)
   }
 }
+
+export const deleteProjectBE = async (id) => {
+  const url = process.env.REACT_APP_BACKEND_URL + `api/v1/projects/${id}`
+  try {
+    const response = await fetch(url, {
+      method: 'DELETE',
+      body: JSON.stringify({id: id}),
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    })
+    const msg = await response.json()
+    console.log(msg)
+  } catch (error) {
+    console.log(error)
+  }
+}


### PR DESCRIPTION
## Title: Delete Project and Linked Palettes

#### Description of changes made: 

- Delete a project from the store

- Delete linked palettes from the store

- Delete project from BE (using the apiCalls helper file; can probably refactor)

- Delete linked palettes from BE

#### Questions that came up:
Right now I'm deleting projects/palettes from the store by just resetting the store with the projects/palettes that we don't want to delete. Performance-wise, it might be better to splice those projects/palettes from the arrays in the store, so we should consider creating a new action for that. For now it works though. 

#### Link to issue this PR addresses: 
[Delete project](https://github.com/easbell/palette-picker-ui/issues/33)

#### Link to new issues that address next steps: 
Not necessarily next steps, but added two issues: 
[Refactor removing projects/palettes from store](https://github.com/easbell/palette-picker-ui/issues/37)
[Refactor apiCalls in helper file](https://github.com/easbell/palette-picker-ui/issues/38)