### PR TITLE
Check dupes

### DIFF
--- a/src/Palette/__snapshots__/Palette.test.js.snap
+++ b/src/Palette/__snapshots__/Palette.test.js.snap
@@ -17,31 +17,31 @@ exports[`Palette should match snapshot 1`] = `
     className="palette"
   >
     <Color
-      color="#383432"
+      color="#3CC839"
       key="0"
       lockColor={[Function]}
       savePalette={[Function]}
     />
     <Color
-      color="#CF6452"
+      color="#FAEC0B"
       key="1"
       lockColor={[Function]}
       savePalette={[Function]}
     />
     <Color
-      color="#D9F4BF"
+      color="#038907"
       key="2"
       lockColor={[Function]}
       savePalette={[Function]}
     />
     <Color
-      color="#FB538D"
+      color="#339BD7"
       key="3"
       lockColor={[Function]}
       savePalette={[Function]}
     />
     <Color
-      color="#A3A9AA"
+      color="#E84946"
       key="4"
       lockColor={[Function]}
       savePalette={[Function]}

--- a/src/PaletteForm/PaletteForm.js
+++ b/src/PaletteForm/PaletteForm.js
@@ -23,16 +23,21 @@ export class PaletteForm extends Component {
 
   handleSubmit = async (e) => {
     e.preventDefault();
-    await this.addProject()
-    this.addPalette()
+    const newName = this.state.projectName.toUpperCase()
+    const projectNames = this.props.projects.map(project => project.name)
+    if (projectNames.includes(newName)) {
+      console.log(`${newName} already exists. Please choose another name for your project`)
+    } else {
+      await this.addProject(newName)
+      this.addPalette()
+    }
   }
   
-  addProject = async () => {
-    const { projectName } = this.state;
+  addProject = async (newName) => {
     const url = process.env.REACT_APP_BACKEND_URL + 'api/v1/projects/'
     const optionsObject = {
       method: 'POST',
-      body: JSON.stringify({name: projectName}),
+      body: JSON.stringify({name: newName}),
       headers: { 
         'Content-Type': 'application/json'
       }

--- a/src/PaletteForm/PaletteForm.test.js
+++ b/src/PaletteForm/PaletteForm.test.js
@@ -13,7 +13,7 @@ describe('PaletteForm', () => {
 
   beforeEach(() => {
     mockFn = jest.fn();
-    mockProjects = [{id: 1, name: 'project'}, {id: 2, name: 'project'}];
+    mockProjects = [{id: 1, name: 'PROJECT'}, {id: 2, name: 'project'}];
     mockColors = {
       color1: {color: 'red'},
       color2: {color: 'red'},
@@ -41,6 +41,13 @@ describe('PaletteForm', () => {
     wrapper.find('.name-input').simulate('change', mockEvent);
     expect(wrapper.state('paletteName')).toBe('new palette');
   });
+
+  it('should not invoke addProject if a project name already exist', async () => {
+    const addProjectSpy = jest.spyOn(wrapper.instance(), 'addProject')
+    wrapper.setState({projectName: 'project'})
+    await wrapper.find('form').simulate('submit', {preventDefault: () => {}})
+    expect(addProjectSpy).not.toHaveBeenCalled()
+  })
 
   it('should invoke addProject and addPalette when handleSubmit is invoked', async () => {
     const addProjectSpy = jest.spyOn(wrapper.instance(), 'addProject')

--- a/src/PaletteForm/__snapshots__/PaletteForm.test.js.snap
+++ b/src/PaletteForm/__snapshots__/PaletteForm.test.js.snap
@@ -35,7 +35,7 @@ exports[`PaletteForm should match snapshot 1`] = `
       key="1"
       onClick={[Function]}
     >
-      project
+      PROJECT
     </DropdownItem>
     <DropdownItem
       as={[Function]}


### PR DESCRIPTION
## Title: Prevent duplicate project names

#### Description of changes made: 

- handleSubmit checks a new project name against existing project names

- Added additional test for handleSubmit

#### Link to issue this PR addresses: 
[Add in check for duplicate project names.](https://github.com/easbell/palette-picker-ui/issues/52)
